### PR TITLE
Document in readme how to store secrets in `auth-sources`

### DIFF
--- a/README.org
+++ b/README.org
@@ -94,7 +94,7 @@ Wallabag will not download the images, but using Emacs [[https://www.gnu.org/sof
 (setq url-automatic-caching t)
 #+end_src
 
-* Retrive new entries after =M-x wallabag=
+* Retrieve new entries after =M-x wallabag=
 #+begin_src emacs-lisp
 (add-hook 'wallabag-after-render-hook 'wallabag-search-update-and-clear-filter)
 #+end_src

--- a/README.org
+++ b/README.org
@@ -87,6 +87,37 @@ git clone https://github.com/chenyanming/wallabag.el.git ~/.emacs.d/lisp/wallaba
 #+begin_src emacs-lisp
 (package! wallabag :recipe (:host github :repo "chenyanming/wallabag.el" :files ("*.el" "*.alist" "*.css")))
 #+end_src
+** Store sensitive credentials in ~auth-sources~
+It is insecure to store your sensitive credentials such as the wallabag password and client secret
+in plain text, and especially if you want to be upload it to public servers. You can use Emacs'
+built-in [[https://www.gnu.org/software/emacs/manual/html_mono/auth.html][auth-sources]] library for GPG-encrypted storage of your secrets.
+
+Create a =~/.authinfo.gpg= file with the lines:
+
+#+begin_src
+machine <wallabag-host> login <username> password <password>
+machine <wallabag-client> login <client-id> password <client-secret>
+#+end_src
+
+We can query the information via ~auth-source-search~, but it's more comfortable to define a custom
+wrapper for password lookup, taken from David Wilson's /System Crafters/ [[https://youtu.be/nZ_T7Q49B8Y][Video]] ([[https://github.com/daviwil/emacs-from-scratch/blob/master/show-notes/Emacs-Tips-Pass.org#accessing-passwords-outside-of-emacs][shownotes]]):
+
+#+begin_src emacs-lisp
+  (defun my-lookup-password (&rest keys)
+    "Get password from auth-sources by forwarding keys `auth-source-search' and calling password-function."
+    (let ((result (apply #'auth-source-search keys)))
+      (if result
+          (funcall (plist-get (car result) :secret))
+        nil)))
+#+end_src
+
+Then, we can use that when setting the wallabag password and secret variables in your config above.
+
+#+begin_src emacs-lisp
+  (setq wallabag-password (my-lookup-password :host "<wallabag-host>")
+        wallabag-secret (my-lookup-password :host "<wallabag-client>"))
+#+end_src
+
 
 * Image Caching
 Wallabag will not download the images, but using Emacs [[https://www.gnu.org/software/emacs/manual/html_node/url/Disk-Caching.html][disk caching]] capability. Setting ~url-automatic-caching~ non-nil causes documents to be cached automatically.


### PR DESCRIPTION
This is an easy fix to #16, and the code is taken directly from my suggestions in that PR. In the future one might think about automatizing this more.